### PR TITLE
Dragging implement

### DIFF
--- a/ui/src/components/document/plugins/SideMenu.tsx
+++ b/ui/src/components/document/plugins/SideMenu.tsx
@@ -1,14 +1,21 @@
-import { useState, useRef } from "react"
+import { useState, useRef, useEffect } from "react"
 import NodeMenu from "./NodeMenu.tsx"
+import { TextSelection } from "prosemirror-state"
+import { toggleMark } from "prosemirror-commands"
+import schema from "../build/schema.ts"
+import { insertAtNextPossible } from "./shortcuts.ts"
 
 function SideMenu(props) {
-  console.log(props)
 
   const menuButton = useRef()
   const [nodeMenu, setNodeMenu] = useState(null);
+  const [pos, setPos] = useState(props.menu.pos)
+
+  useEffect(() => {
+    setPos(props.menu.pos)
+  }, [props.menu.pos])
 
   function openNodeMenu(event) {
-    console.log(event)
     const box = event.target.getBoundingClientRect()
     setNodeMenu({
       node: props.menu.node,
@@ -20,7 +27,35 @@ function SideMenu(props) {
   }
 
   function handleDrag(event) {
-    console.log(event)
+    /*
+    const cursor = props.view.posAtCoords({left: event.clientX, top: event.clientY});
+    if(cursor && cursor.pos != pos) {
+      const move = insertAtNextPossible(props.view, cursor.pos, props.menu.node);
+      if(move != null) {
+        const prev = move.tr.mapping.map(pos);
+        //const cleanup = props.view.state.tr.setSelection(new TextSelection(props.view.state.doc.resolve(prev + 1), props.view.state.doc.resolve(prev + props.menu.node.nodeSize - 1)))
+        const cleanup = props.view.state.tr.deleteRange(prev, prev + props.menu.node.nodeSize)
+        props.view.dispatch(cleanup)
+        //toggleMark(schema.marks["strong"])(props.view.state, props.view.dispatch, props.view)
+        setPos(move.pos)
+      }
+    }
+    */
+  }
+
+  function handleDragEnd(event) {
+    const cursor = props.view.posAtCoords({left: event.clientX, top: event.clientY});
+    if(cursor && cursor.pos != pos) {
+      const move = insertAtNextPossible(props.view, cursor.pos, props.menu.node);
+      if(move != null) {
+        const prev = move.tr.mapping.map(pos);
+        //const cleanup = props.view.state.tr.setSelection(new TextSelection(props.view.state.doc.resolve(prev + 1), props.view.state.doc.resolve(prev + props.menu.node.nodeSize - 1)))
+        const cleanup = props.view.state.tr.deleteRange(prev, prev + props.menu.node.nodeSize)
+        props.view.dispatch(cleanup)
+        //toggleMark(schema.marks["strong"])(props.view.state, props.view.dispatch, props.view)
+        setPos(move.pos)
+      }
+    }
   }
 
 
@@ -48,7 +83,7 @@ function SideMenu(props) {
         ""
       )}
       {/* Drag Handle */}
-      <li draggable="true">
+      <li draggable="true" onDrag={handleDrag} onDragEnd={handleDragEnd}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 256 512"

--- a/ui/src/components/document/plugins/sidemenu.ts
+++ b/ui/src/components/document/plugins/sidemenu.ts
@@ -10,8 +10,35 @@ export default (renderMenu: (loc: BlockLocation | null) => void) => {
           if (event.target) {
             const box = (event.target as any).getBoundingClientRect();
             const pos = view.posAtCoords(box);
-            const loc = getBlockLoc(view, view.state.doc, pos.pos);
-            renderMenu(loc);
+            if(pos.inside > 0) {
+              let rendered = false;
+              let lastPos = 0;
+              let lastNode = null;
+              view.state.doc.descendants((node, nodePos) => {
+                if(!rendered && pos.pos < nodePos) {
+                  rendered = true;
+                  const top = (view.domAtPos(lastPos + 1).node as any).getBoundingClientRect().top;
+                  const loc = {
+                    node: lastNode,
+                    pos: lastPos,
+                    top: top,
+                  }
+                  renderMenu(loc);
+                }
+                lastPos = nodePos;
+                lastNode = node;
+                return false;
+              })
+              if(!rendered) {
+                const top = (view.domAtPos(lastPos + 1).node as any).getBoundingClientRect().top;
+                const loc = {
+                  node: lastNode,
+                  pos: lastPos,
+                  top: top,
+                }
+                renderMenu(loc);
+              }
+            }
           } else {
             renderMenu(null);
           }

--- a/ui/src/components/document/plugins/suggestions.ts
+++ b/ui/src/components/document/plugins/suggestions.ts
@@ -1,6 +1,7 @@
 import { EditorView } from "prosemirror-view"
 import { TextSelection } from "prosemirror-state"
 import { Command, setBlockType, wrapIn,  } from "prosemirror-commands"
+import { insertAtNextPossible } from "./shortcuts.ts"
 import schema from "../build/schema.ts"
 
 export interface SuggestionItem {
@@ -121,16 +122,3 @@ const suggestions: { [key: string]: SuggestionItem } = {
 }
 
 export default suggestions
-
-export function insertAtNextPossible(view: EditorView, pos: number, node: any): boolean {
-  let status = false;
-  for (let walk = pos; walk < view.state.doc.nodeSize; walk++) {
-    const tr = view.state.tr.insert(pos, node);
-    if (tr.docChanged) {
-      view.dispatch(tr);
-      status = true;
-      break;
-    }
-  }
-  return status;
-}


### PR DESCRIPTION
side menu can drag top level block

;;; for future work this will need to be implemented for second and maybe third level elements
this can be done by managing the .decendents(() => ) return value for certain node types (like lists or blockquotes)