### PR TITLE
Update Main Hoon Branch With Basic Document Scries

### DIFF
--- a/desk/app/engram.hoon
+++ b/desk/app/engram.hoon
@@ -99,7 +99,25 @@
 ::
 ++  on-watch  on-watch:def
 ++  on-leave  on-leave:def
-++  on-peek   on-peek:def
+++  on-peek
+  |=  =path
+  ^-  (unit (unit cage))
+  ?+    path  (on-peek:def path)
+      [%x %docinfo ~]
+    =/  k=(set [owner=@p id=@ name=@t])  ~(key by d)
+    ``noun+!>(k)
+  ::
+      [%x %gdoc @ @ @ ~]
+    =/  owner=@p  (slav %p i.t.t.path)
+    =/  id=@  (slav %ud i.t.t.t.path)
+    =/  name=@t  (crip (trip i.t.t.t.t.path))
+    =/  meta  [owner=owner id=id name=name]
+    =/  doc=[version=(list @ud) cont=(list @ud)]  (need (~(get by d) meta))
+    :: ~&  (need doc)
+    :: =/  who=@p  (slav %p i.t.t.path)
+    ``noun+!>(doc)
+  ==
+::
 ++  on-agent  on-agent:def
 ++  on-arvo   on-arvo:def
 ++  on-fail   on-fail:def


### PR DESCRIPTION
This is a WIP branch, however to allow for development on the interactions between Hoon and the React frontend the changes as of right now will be merged up.  As this is WIP there might be some bugs, as well as not all scries are implemented so the branch will stay alive.

The working scries are as follows:
- fetching document metadata (returns a set of document indexes)
- fetching a document from metadata (returns the document state)