### PR TITLE
Ability to remove snapshots

### DIFF
--- a/desk/app/engram.hoon
+++ b/desk/app/engram.hoon
@@ -54,11 +54,17 @@
     ::
     ::
     ::
-     %snap
+      %snap
     ~&  "adding snap"
     ~&  action
     ~&  su
     `this(su (~(add ja su) dmeta.action snap.action))
+    ::
+    ::
+    ::
+      %dnsap
+    ?>  (~(has by su) dmeta.action)
+    `this(su (~(del by su) dmeta.action))
     ::
     :: modify a document by changing the stored document state
     ::

--- a/desk/sur/engram.hoon
+++ b/desk/sur/engram.hoon
@@ -59,6 +59,7 @@
   $%  [%make =dmeta =doc]
       [%createsnap =dmeta]
       [%snap =dmeta =snap]
+      [%dsnap =dmeta]
       [%save =dmeta =doc]
       [%delete =dmeta]
       [%settings =dmeta =stg]


### PR DESCRIPTION
Allow for the removal of snapshots when a document gets deleted.  This allows for a completely clean state when a user removes a document from their ship's state.