### PR TITLE
patch 2/9/23

### DIFF
--- a/desk/app/engram.hoon
+++ b/desk/app/engram.hoon
@@ -15,12 +15,14 @@
 |%
 +$  versioned-state
   $%  state-0
+      state-1
   ==
-+$  state-0  [%0 t=localtime h=history s=spaces d=documents f=folders u=updates]
++$  state-0  [v=%0 t=localtime h=history s=spaces d=documents f=folders u=(jug id dupdate)]
++$  state-1  [v=%1 t=localtime h=history s=spaces d=documents f=folders u=updates]
 +$  card  card:agent:gall
 --
 %-  agent:dbug
-=|  state-0
+=|  state-1
 =*  state  -
 ^-  agent:gall
 |_  =bowl:gall
@@ -40,7 +42,8 @@
   ^-  (quip card _this)
   =/  old  !<(versioned-state old-state)
   ?-  -.old
-    %0  :_  this(state old)
+    %0  `this(state [%1 t.old h.old s.old d.old f.old ^*(updates)])
+    %1  :_  this(state old)
         %+  weld
           %+  weld  
             %+  turn  ~(tap in ~(key by s.old))
@@ -820,7 +823,7 @@
     ~&  "No space of path: {<`path`~[i.t.t.p i.t.t.t.p]>}"  !!
     ::
       [%x %document %list ~]
-    ``noun+!>((list:document:enjs:engram d))
+    ``noun+!>((listall:document:enjs:engram d))
   ::
       [%x %document @ @ %get ~]
     ?>  =(src.bowl our.bowl)
@@ -855,17 +858,9 @@
     =/  id=id  [`@p`(slav %p i.t.t.p) `@u`(slav %ud i.t.t.t.p)]
     =/  doc  (~(got by d) id)
     ?:  (~(has by u) id)
-      =/  updts  (need (~(get by u) id))
+      =/  updts  ~(val by (~(got by u) id))
       ``noun+!>((content:document:enjs:engram [doc updts]))
-    ``noun+!>((content:document:enjs:engram [doc ^*((set dupdate))]))
-  ::
-      [%x %document @ @ %updates ~]
-    ?>  =(src.bowl our.bowl)
-    =/  id=id  [`@p`(slav %p i.t.t.p) `@u`(slav %ud i.t.t.t.p)]
-    ?:  (~(has by u) id)
-      =/  updts  (need (~(get by u) id))
-      ``noun+!>((updates:document:enjs:engram updts))
-    ``noun+!>((updates:document:enjs:engram ^*((set dupdate))))
+    ``noun+!>((content:document:enjs:engram [doc ^*((list dupdate))]))
   ::
       [%x %folder @ @ %list ~]
     ?>  =(src.bowl our.bowl)
@@ -935,8 +930,14 @@
               doc
             =/  dstate  this(d (~(put by d) id ndoc))
             ::  Update Changes
-            ::~&  "--- Sunk Document :) ---"  
-            :_  dstate(u (~(gas ju u) content.update.res))
+            ::~&  "--- Sunk Document :) ---"
+            =/  nextu  %^  spin  
+                         content.update.res  
+                      (~(got by u) id)
+                    |=  [a=dupdate b=(map @p dupdate)]
+                    [a (~(put by b) author.a a)]
+                    ::(~(put by b) id (~(put by (~(got by b) id)) author.a a))
+            :_  dstate(u (~(put by u) id +.nextu))
             :~  [%give %fact ~[/updates] %json !>((pairs:enjs:format ~[['space' (path:enjs:format space.settings.doc)] ['type' (tape:enjs:format "document")] ['id' (path:enjs:format path.res)]]))]
             ==
             ::

--- a/desk/lib/engram.hoon
+++ b/desk/lib/engram.hoon
@@ -131,7 +131,7 @@
     --
   ++  document
     |%
-    ++  list
+    ++  listall
       =,  enjs:format
       |=  docs=documents:engram
       ^-  json
@@ -182,25 +182,15 @@
       ==
     ++  content
       =,  enjs:format
-      |=  [doc=document:engram updts=(set dupdate:engram)]
+      |=  [doc=document:engram updts=(list dupdate:engram)]
       ^-  json
       %-  pairs  :~
         ['content' (tape content.doc)]
-        :-  'updates'  %-  pairs  %~  tap  in
-          ^-  (set [@t json])
-          %-  ~(run in updts)
+        :-  'updates'  %-  pairs
+          %+  turn  updts
           |=  updt=dupdate:engram
           [(scot %da timestamp.updt) (pairs ~[['author' (tape (scow %p author.updt))] ['content' (tape content.updt)]])]
       ==
-    ++  updates
-      =,  enjs:format
-      |=  updts=(set dupdate:engram)
-      ^-  json
-      %-  pairs  %~  tap  in
-          ^-  (set [@t json])
-          %-  ~(run in updts)
-          |=  updt=dupdate:engram
-          [(scot %da timestamp.updt) (pairs ~[['author' (tape (scow %p author.updt))] ['content' (tape content.updt)]])]
     ++  snapshots
       =,  enjs:format
       |=  snaps=(set dsnapshot:engram)

--- a/desk/lib/engram.hoon
+++ b/desk/lib/engram.hoon
@@ -172,6 +172,7 @@
       |=  settings=dsettings:engram
       ^-  json
       %-  pairs  :~
+        ['space' (path space.settings)]
         ['owner' (tape (scow %p owner.settings))]
         :-  'ships'  %-  pairs  %+  turn  ~(tap by content.ships.settings)  
           |=  [id=id:index [ship=@p level=@tas]]  

--- a/desk/sur/engram.hoon
+++ b/desk/sur/engram.hoon
@@ -46,7 +46,7 @@
 +$  localtime  clock
 +$  history  (list id)
 +$  spaces  (map spath space)
-+$  updates  (jug id dupdate)
++$  updates  (map id (map @p dupdate))
 +$  documents  (map id document)
 +$  folders  (map id folder)
 ::
@@ -130,7 +130,7 @@
   $%  [%none ~]
       [%gather-document-success ~]
       [%delta-document-success ~]
-      [%sync-document-success path=path peer=@p update=[name=@t roles=(update:index [@tas @tas]) ships=(update:index [@p @tas]) content=(list [id:index dupdate])]]
+      [%sync-document-success path=path peer=@p update=[name=@t roles=(update:index [@tas @tas]) ships=(update:index [@p @tas]) content=(list dupdate)]]
       [%gather-folder-success ~]
       [%delta-folder-success ~]
       [%sync-folder-success path=path peer=@p update=[name=@t roles=(update:index [@tas @tas]) ships=(update:index [@p @tas]) content=(update:index [id @tas])]]

--- a/desk/ted/sync-document.hoon
+++ b/desk/ted/sync-document.hoon
@@ -26,7 +26,7 @@
       name.update
       roles.update
       ships.update
-      %+  turn  ~(tap in content.update)  |=  a=dupdate  [id a]
+      content.update
     ==
 ==
 --

--- a/ui/src/components/dock/SharingDock.vue
+++ b/ui/src/components/dock/SharingDock.vue
@@ -22,7 +22,7 @@
         :key="item" 
         :role="roles[item].role" 
         :level="roles[item].level" 
-        v-for="item in Object.keys(roles)" 
+        v-for="item in (space == $route.query.spaceId ? Object.keys(roles) : [])" 
         @level="(event: string) => { handleLevel(item, event, 'roles') }"
       />
     </div>
@@ -76,6 +76,9 @@ export default defineComponent({
     ships: function() {
       return store.getters['filesys/ships'](this.docId);
     },
+    space: function() {
+      return store.getters['filesys/owner'](this.docId);
+    },
     isAdmin: function(): boolean {
       const myroles = store.getters['space/myroles'];
       const owner = store.getters['filesys/owner'](this.docId);
@@ -87,11 +90,14 @@ export default defineComponent({
               }).reduce((a: boolean, acc: boolean) => {
                       return acc || a;
                   }, false) || 
-          Object.keys(this.roles)
+          (
+            this.space == this.$route.query.spaceId &&
+            Object.keys(this.roles)
               .map((timestamp: string) => { return myroles.includes(this.roles[timestamp].role) && this.roles[timestamp].level == "admin" })
                   .reduce((a: boolean, acc: boolean) => {
                       return acc || a;
-                  }, false);
+                  }, false)
+          ); 
     },
   },
   methods: {

--- a/ui/src/components/document/Document.vue
+++ b/ui/src/components/document/Document.vue
@@ -133,6 +133,7 @@ export default defineComponent({
     editable: function(id: string): boolean {
       const myroles = store.getters['space/myroles'];
       if(!store.getters['filesys/get'](id)) return false;
+      const space = store.getters['filesys/space'](id);
       const owner = store.getters['filesys/owner'](id);
       const roles = store.getters['filesys/roles'](id);
       const ships = store.getters['filesys/ships'](id);
@@ -142,12 +143,15 @@ export default defineComponent({
               .map((timestamp: string) => { return ships[timestamp] })
                   .reduce((a: ShipPermission, acc: boolean) => {
                       return acc || (a.ship == `~${(window as any).ship}` && (a.level == "editor" || a.level == "admin"));
-                  }, false) || 
-          Object.keys(roles)
-              .map((timestamp: string) => { return roles[timestamp] })
-                  .reduce((a: RolePermission, acc: boolean) => {
-                      return acc || (myroles.includes(a.role) && (a.level == "editor" || a.level == "admin"));
-                  }, false);
+                  }, false) ||
+          (
+            space == this.$route.query.spaceId && 
+            Object.keys(roles)
+                .map((timestamp: string) => { return roles[timestamp] })
+                    .reduce((a: RolePermission, acc: boolean) => {
+                        return acc || (myroles.includes(a.role) && (a.level == "editor" || a.level == "admin"));
+                    }, false)
+          );
     }
   },
   computed: {

--- a/ui/src/components/document/Document.vue
+++ b/ui/src/components/document/Document.vue
@@ -99,7 +99,8 @@ export default defineComponent({
   methods: {
     open: function(docId: string, snapshot: null | DocumentVersion = null) {
       this.loading = true;
-      this.loaded = render(
+      store.dispatch("filesys/protectedget", {id: docId, type: "document"}).then(() => {
+        this.loaded = render(
               this.$refs["document"] as any, 
               docId, 
               (this as any).pushMenu, 
@@ -115,7 +116,7 @@ export default defineComponent({
         console.error("problem loading document");
         this.missing = true;
       })
-
+      })
     },
     updateCover: function (cover: CoverUpdate) {
       this.cover = { ...this.cover, ...cover };

--- a/ui/src/components/document/prosemirror/render.ts
+++ b/ui/src/components/document/prosemirror/render.ts
@@ -72,6 +72,7 @@ export default function (
         }
 
         // Push current updates
+        console.warn("updates: ", res.updates);
         Object.keys(res.updates).map((key: string) => { return res.updates[key] }).forEach((update: any) => {
           pushUpdate(path, update);
         });

--- a/ui/src/components/document/styles/document.css
+++ b/ui/src/components/document/styles/document.css
@@ -92,6 +92,7 @@ pre {
   border-radius: theme(spacing.2);
   background-color: theme(colors.border);
   font-family: JetBrains Mono, monospace;
+  white-space: pre-wrap;
 }
 
 hr {

--- a/ui/src/store/filesystem.ts
+++ b/ui/src/store/filesystem.ts
@@ -20,6 +20,7 @@ export interface SysItem {
     }
 
     owner: string,
+    space?: string,
     ships: { [key: string]: ShipPermission },
     roles: { [key: string]: RolePermission },
 
@@ -33,6 +34,7 @@ export interface FileSysState {
         type: "folder",
         name: "root",
         children: { [id: string]: SysRecord },
+        space: undefined,
         owner: "",
         ships: {},
         roles: {},
@@ -55,6 +57,7 @@ const state: FileSysState = {
         type: "folder",
         name: "root",
         children: {},
+        space: undefined,
         owner: "",
         ships: {},
         roles: {},
@@ -82,6 +85,9 @@ const getters: GetterTree<FileSysState, RootState> = {
     },
 
     // Permissions
+    space: (state) => (id: string): undefined | string => {
+        return state[id].space;
+    },
     owner: (state) => (id: string): undefined | string => {
         return state[id].owner;
     },
@@ -138,6 +144,7 @@ const mutations: MutationTree<FileSysState> = {
             type: "folder",
             name: "root",
             children: {},
+            space: undefined,
             owner: "",
             ships: {},
             roles: {}


### PR DESCRIPTION
- code blocks wrap properly
- non-space documents no longer show roles in their permissions
- non-space documents wait for permission to load before rendering (corrects issues with editability)
- updates are now stored as a map (@p => update) instead of a raw set, dramatically increasing the efficiency of updates